### PR TITLE
Chore: add additional sanity checks for `fee` in `main` transition

### DIFF
--- a/app.zk_sonic.leo
+++ b/app.zk_sonic.leo
@@ -8,6 +8,9 @@ program zk_sonic.aleo {
         value: u64,
         blinding: field,
     }
+// Additional sanity checks for `fee`
+assert(fee >= 0u64);
+assert(fee <= old_value);
 
     // Minimal wrapper around a Pedersen-style commitment.
     // In a real protocol this would match the on-chain commitment function.


### PR DESCRIPTION
## Summary

While there are checks in place for `fee`, it would be beneficial to add more validation to ensure it doesn't exceed the limits or break basic assumptions.

## Proposed Changes

- Add more sanity checks to the `main` transition to ensure the `fee` value is not greater than the `old_value`.
- Add bounds checking on the fee value (e.g., not negative, not larger than `old_value`).

## Motivation

- Ensures that invalid fee values are caught and prevents logical errors in the transaction process.
- Enhances the security and reliability of the protocol.