### PR TITLE
Feature: add --help flag to display usage instructions

### DIFF
--- a/app.zk_sonic.leo
+++ b/app.zk_sonic.leo
@@ -65,6 +65,8 @@ program zk_sonic.aleo {
         // Recompute commitments from private witnesses
         let computed_old_commitment: field = note_commitment(old_note);
         let computed_new_commitment: field = note_commitment(new_note);
+p = argparse.ArgumentParser(description="Simulate confidential transactions using zk‑sonic rollup.")
+p.add_argument("--help", help="Show this help message and exit", action="help")
 
         // Soundness: commitments must match the public inputs
         assert(computed_old_commitment == old_commitment);


### PR DESCRIPTION
## Summary

Adding a `--help` flag provides users with a quick way to get information about how to use the script, what options are available, and any additional details.

## Proposed Changes

- Add `--help` support to display a usage guide automatically when invoked.  
- Ensure the script provides clear documentation for the available flags.

## Motivation

- Helps users understand how to use the script without needing to read external documentation.
- Provides a better user experience, especially for new users.